### PR TITLE
Add git-cleanup.bat for repository maintenance

### DIFF
--- a/scripts/git-cleanup.bat
+++ b/scripts/git-cleanup.bat
@@ -1,0 +1,23 @@
+@echo off
+
+git rev-parse --is-inside-work-tree >nul 2>&1
+if errorlevel 1 (
+    echo Not inside a Git repository.
+    exit /b 1
+)
+
+echo Fetching and pruning remotes...
+git fetch -p >nul 2>&1
+echo Done.
+echo.
+
+for /f "tokens=1" %%b in ('git branch -vv ^| findstr /c:"[gone]"') do (
+    echo Deleting branch: %%b
+    git branch -d %%b >nul 2>&1
+)
+
+echo.
+echo Cleanup complete!
+echo.
+
+pause


### PR DESCRIPTION
This script fetches and prunes remotes, then deletes local branches that no longer have a remote counterpart.